### PR TITLE
Add quest assignment api and test

### DIFF
--- a/app.py
+++ b/app.py
@@ -446,11 +446,11 @@ def assign_quests():
         "assignments": [
             {
                 "websiteId": 12345,
-                "quest_name": "rec123abc"
+                "quest_name": "Garlic Guardians"
             },
             {
                 "websiteId": 12346,
-                "quest_name": "rec456def"
+                "quest_name": "Electric Orchard"
             }
         ]
     }


### PR DESCRIPTION
Can be used like so:

POST 

https://localhost:5000/assign-quests

Expected json body format:
```yaml
    {
        "assignments": [
            {
                "websiteId": 12345,
                "quest_name": "Garlic Guardians"
            },
            {
                "websiteId": 12346,
                "quest_name": "Electric Orchard"
            }
        ]
    }
```