### PR TITLE
change to field name to reflect changes to database

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-AIRTABLE_BASE_ID=your_base_id
+AIRTABLE_BASE_ID=app1ab9xe953jYQ1x
 AIRTABLE_TABLE_NAME=your_table_name
-AIRTABLE_API_KEY=your_airtable_api_key
-ENVIRONMENT_MODE=Production
+AIRTABLE_API_KEY=patD6NmbVEAxFOlil.b59589b5acca56738fea2db82ece81e813d46823cbb394bfd2a1b869f868d259
+ENVIRONMENT_MODE=Development
 ADMIN_PASSWORD_HASH=your_admin_password_hash

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Thumbs.db
 
 # Database
 data/
+.env

--- a/student_data_manager.py
+++ b/student_data_manager.py
@@ -208,10 +208,12 @@ class StudentDataManager:
             parsed_student = parse_database_row(student_row)
             old_current_step = parsed_student.get("current_step", "")
             old_current_quest = parsed_student.get("current_quest", "")
+            
             current_quest = old_current_quest if old_current_quest else ""
             
             # Use get_value_by_row_and_column to look up the quest for this step
-            step_quest_id = step_manager.get_value_by_row_and_column("name", new_current_step, "craffft_quests")
+            step_quest_id = step_manager.get_value_by_row_and_column("name", new_current_step, "craffft_quest_id")
+        
             if not step_quest_id:
                 return {
                     "success": False,


### PR DESCRIPTION
The changes to the step table changed craffft_quests to craffft_quest_id the other name is a remant from the way airtable treats linked records. 

currently in steps it will require the full quest name as thats how it compares to see if it belongs to the current quest
